### PR TITLE
fix: handle jsonl 'null' rows

### DIFF
--- a/tap_universal_file/client.py
+++ b/tap_universal_file/client.py
@@ -152,6 +152,8 @@ class FileStream(Stream):
         Returns:
             A dictionary representing a row containing additional information columns.
         """
+        if not row:
+            row = {}
         additional_info = self.config["additional_info"]
         if additional_info:
             row.update({"_sdc_file_name": file_name})


### PR DESCRIPTION
We encountered the following in our data files

```jsonl
{"id": "1"}
null
{"id": "3"}
```

... which we found charming.

This caused `row` to be `None` in `add_additional_info()`, so we handled it by creating a blank dict.  I'm not sure if this is the best way to handle it or whether it warrants its own config value, i.e. `jsonl_null_string_rows` or some such.  This works for us for now.