### PR TITLE
timestamp before ListBucket to omit writes

### DIFF
--- a/tap_universal_file/files.py
+++ b/tap_universal_file/files.py
@@ -96,6 +96,9 @@ class FilesystemManager:
         none_synced = True
 
         file_dict_list = []
+        # Note: the `five_minutes_ago` variable is super-hard-coded to a Fragile use case.
+        #       This should be configurable in the future.
+        five_minutes_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
 
         for file_path in self.filesystem.find(self.config["file_path"]):
             file = self.filesystem.info(file_path)
@@ -122,9 +125,6 @@ class FilesystemManager:
 
         # Only yield files when no replication key is present or when the file is newer
         # than the replication key value, as a datetime.
-        # Note: the `five_minutes_ago` variable is super-hard-coded to a Fragile use case.
-        #       This should be configurable in the future.
-        five_minutes_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
         for file_dict in file_dict_list:
             if starting_replication_key_value is None or (
                 file_dict["last_modified"] >= datetime.datetime.strptime(


### PR DESCRIPTION
turns out ListBucket takes long enough that the timestamp for 5 mins needs to be taken at the beginning of the process